### PR TITLE
pull a tag of pear_exception, not the master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": ">=5.3.0",
-        "pear/pear_exception": "dev-master"
+        "pear/pear_exception": "^1.0"
     },
     "autoload": {
         "psr-0": { "Services_Atlassian_" : "lib" }


### PR DESCRIPTION
this way users do not need to add pear_exception: dev-master to their composer.json files, as it is now:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for smurfy/atlassian-services-crowd ^1.0 -> satisfiable by smurfy/atlassian-services-crowd[1.0.0].
    - smurfy/atlassian-services-crowd 1.0.0 requires pear/pear_exception dev-master -> no matching package found.

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting

```
